### PR TITLE
Restartable formatter

### DIFF
--- a/calva-fmt/docmirror/clojure-lexer.ts
+++ b/calva-fmt/docmirror/clojure-lexer.ts
@@ -20,8 +20,13 @@ let toplevel = new LexicalGrammar();
 toplevel.terminal("\\s+", (l, m) => ({ type: "ws" }))
 // comments
 toplevel.terminal(";.*", (l, m) => ({ type: "comment" }))
+// open parens
+toplevel.terminal("\\(|\\[|\\{|#\\(|#?\\(|#\\{", (l, m) => ({ type: "open" }))
+// close parens
+toplevel.terminal("\\)|\\]|\\}", (l, m) => ({ type: "close" }))
+
 // punctuators
-toplevel.terminal("\\(|\\)|\\[|\\]|\\{|\\}|#\\{|,|~@|~|'|#'|#:|#_|^|#\\(|`|#?\\(", (l, m) => ({ type: "punc" }))
+toplevel.terminal(",|~@|~|'|#'|#:|#_|\\^|`|#|\\^:", (l, m) => ({ type: "punc" }))
 // this is a REALLY lose symbol definition, but similar to how clojure really collects it. numbers/true/nil are all 
 toplevel.terminal("[^()[\\]\\{\\}#,~@'`^\"\\s]+", (l, m) => ({ type: "id" }))
 // complete string on a single line
@@ -82,10 +87,11 @@ export class Scanner {
                         lex.position = oldpos;
                         break;
                 }
-                this.state = { ...this.state }
                 tks.push({ ...tk, state: this.state });
             }
         } while(tk);
+        // insert a sentinel EOL value, this allows us to simplify TokenCaret's implementation.
+        tks.push({ type: "eol", raw: "", offset: line.length, state: this.state })
         return tks;
     }
 }

--- a/calva-fmt/docmirror/clojure-lexer.ts
+++ b/calva-fmt/docmirror/clojure-lexer.ts
@@ -76,7 +76,7 @@ export class Scanner {
             }
         } while(tk);
         // insert a sentinel EOL value, this allows us to simplify TokenCaret's implementation.
-        tks.push({ type: "eol", raw: "", offset: line.length, state: this.state })
+        tks.push({ type: "eol", raw: "\n", offset: line.length, state: this.state })
         return tks;
     }
 }

--- a/calva-fmt/docmirror/clojure-lexer.ts
+++ b/calva-fmt/docmirror/clojure-lexer.ts
@@ -34,6 +34,7 @@ toplevel.terminal('"([^"\\\\]|\\\\.)*"', (l, m) => ({ type: "str"}))
 
 // begin a multiline string
 toplevel.terminal('"([^"\\\\]|\\\\.)*', (l, m) => ({ type: "str-start"}))
+toplevel.terminal('.', (l, m) => ({ type: "junk" }))
 
 
 // Inside a multi-line string lexical grammar

--- a/calva-fmt/docmirror/clojure-lexer.ts
+++ b/calva-fmt/docmirror/clojure-lexer.ts
@@ -49,21 +49,6 @@ export interface ScannerState {
     inString: boolean
 }
 
-const OPEN_PARS = {
-    "(": "(",
-    "#(": "(",
-    "#?(": "(",
-    "#{": "{",
-    "{": "{",
-    "[": "["
-}
-
-const CLOSE_PARS = {
-    ")": "(",
-    "]": "[",
-    "}": "{"
-}
-
 export class Scanner {
     state: ScannerState = { inString: false };
     processLine(line: string, lineNumber: number, state: ScannerState = this.state) {

--- a/calva-fmt/docmirror/clojure-lexer.ts
+++ b/calva-fmt/docmirror/clojure-lexer.ts
@@ -17,7 +17,7 @@ export interface Token extends LexerToken {
 let toplevel = new LexicalGrammar();
 
 // whitespace
-toplevel.terminal("\\s+", (l, m) => ({ type: "ws" }))
+toplevel.terminal("[\\s,]+", (l, m) => ({ type: "ws" }))
 // comments
 toplevel.terminal(";.*", (l, m) => ({ type: "comment" }))
 // open parens
@@ -26,7 +26,7 @@ toplevel.terminal("\\(|\\[|\\{|#\\(|#?\\(|#\\{", (l, m) => ({ type: "open" }))
 toplevel.terminal("\\)|\\]|\\}", (l, m) => ({ type: "close" }))
 
 // punctuators
-toplevel.terminal(",|~@|~|'|#'|#:|#_|\\^|`|#|\\^:", (l, m) => ({ type: "punc" }))
+toplevel.terminal("~@|~|'|#'|#:|#_|\\^|`|#|\\^:", (l, m) => ({ type: "punc" }))
 // this is a REALLY lose symbol definition, but similar to how clojure really collects it. numbers/true/nil are all 
 toplevel.terminal("[^()[\\]\\{\\}#,~@'`^\"\\s]+", (l, m) => ({ type: "id" }))
 // complete string on a single line

--- a/calva-fmt/docmirror/clojure-lexer.ts
+++ b/calva-fmt/docmirror/clojure-lexer.ts
@@ -27,8 +27,14 @@ toplevel.terminal("\\)|\\]|\\}", (l, m) => ({ type: "close" }))
 
 // punctuators
 toplevel.terminal("~@|~|'|#'|#:|#_|\\^|`|#|\\^:", (l, m) => ({ type: "punc" }))
+
+toplevel.terminal("true|false|nil", (l, m) => ({type: "lit"}))
+toplevel.terminal("[0-9]+[rR][0-9a-zA-Z]+", (l, m) => ({ type: "lit" }))
+toplevel.terminal("[-+]?[0-9]+(\\.[0-9]+)?([eE][-+]?[0-9]+)?", (l, m) => ({ type: "lit" }))
+
+toplevel.terminal(":[^()[\\]\\{\\}#,~@'`^\"\\s]+", (l, m) => ({ type: "lit" }))
 // this is a REALLY lose symbol definition, but similar to how clojure really collects it. numbers/true/nil are all 
-toplevel.terminal("[^()[\\]\\{\\}#,~@'`^\"\\s]+", (l, m) => ({ type: "id" }))
+toplevel.terminal("[^()[\\]\\{\\}#,~@'`^\"\\s:][^()[\\]\\{\\}#,~@'`^\"\\s]*", (l, m) => ({ type: "id" }))
 // complete string on a single line
 toplevel.terminal('"([^"\\\\]|\\\\.)*"', (l, m) => ({ type: "str"}))
 

--- a/calva-fmt/docmirror/clojure-lexer.ts
+++ b/calva-fmt/docmirror/clojure-lexer.ts
@@ -1,0 +1,47 @@
+import { LexicalGrammar, Token } from "./lexer";
+export type Token = Token;
+
+let toplevel = new LexicalGrammar();
+toplevel.terminal("\\s+", (l, m) => ({ type: "ws" }))
+toplevel.terminal(";.*", (l, m) => ({ type: "comment" }))
+toplevel.terminal("\\(|\\)|\\[|\\]|\\{|\\}|#\\{|,|~@|~|'|#'|#:|#_|^|#\\(|`|#?\\(", (l, m) => ({ type: "punc" }))
+toplevel.terminal("[^()[\\]\\{\\}#,~@'`^\"\\s]+", (l, m) => ({ type: "id" }))
+toplevel.terminal('"(\\\\.|[^"]+)*"', (l, m) => ({ type: "str"}))
+toplevel.terminal('"([^"]+|\\\\.)*', (l, m) => ({ type: "str-start"}))
+
+let multstring = new LexicalGrammar()
+multstring.terminal('([^"]|\\\\.)*"', (l, m) => ({ type: "str-end" }))
+multstring.terminal('([^"]|\\\\.)*', (l, m) => ({ type: "str" }))
+
+export type ScannerState = { inString: boolean }
+
+export class Scanner {
+    state: ScannerState = { inString: false };
+    processLine(line: string, state: ScannerState = this.state) {
+        let tks: Token[] = [];
+        this.state = state;
+        let lex = (this.state.inString ? multstring : toplevel).lex(line);
+        let tk: Token;
+        try {
+            do {
+                tk = lex.scan();
+                if(tk) {
+                    let oldpos = lex.position;
+                    if(tk.type == "str-end") {
+                        this.state = { ...this.state, inString: false};
+                        lex = toplevel.lex(line);
+                        lex.position = oldpos;
+                    } else if (tk.type == "str-start") {
+                        this.state = { ...this.state, inString: true};
+                        lex = multstring.lex(line);
+                        lex.position = oldpos;
+                    }
+                    tks.push(tk);
+                }
+            } while(tk);
+        } catch(e) {
+            debugger
+        }
+        return tks;
+    }
+}

--- a/calva-fmt/docmirror/clojure-lexer.ts
+++ b/calva-fmt/docmirror/clojure-lexer.ts
@@ -30,18 +30,18 @@ toplevel.terminal("~@|~|'|#'|#:|#_|\\^|`|#|\\^:", (l, m) => ({ type: "punc" }))
 // this is a REALLY lose symbol definition, but similar to how clojure really collects it. numbers/true/nil are all 
 toplevel.terminal("[^()[\\]\\{\\}#,~@'`^\"\\s]+", (l, m) => ({ type: "id" }))
 // complete string on a single line
-toplevel.terminal('"(\\\\.|[^"]+)*"', (l, m) => ({ type: "str"}))
+toplevel.terminal('"([^"\\\\]|\\\\.)*"', (l, m) => ({ type: "str"}))
 
 // begin a multiline string
-toplevel.terminal('"([^"]+|\\\\.)*', (l, m) => ({ type: "str-start"}))
+toplevel.terminal('"([^"\\\\]|\\\\.)*', (l, m) => ({ type: "str-start"}))
 
 
 // Inside a multi-line string lexical grammar
 let multstring = new LexicalGrammar()
 // end a multiline string
-multstring.terminal('([^"]|\\\\.)*"', (l, m) => ({ type: "str-end" }))
+multstring.terminal('([^"\\\\]|\\\\.)*"', (l, m) => ({ type: "str-end" }))
 // still within a multiline string
-multstring.terminal('([^"]|\\\\.)*', (l, m) => ({ type: "str-inside" }))
+multstring.terminal('([^"\\\\]|\\\\.)*', (l, m) => ({ type: "str-inside" }))
 
 /** The state of the scanner */
 export interface ScannerState {

--- a/calva-fmt/docmirror/clojure-lexer.ts
+++ b/calva-fmt/docmirror/clojure-lexer.ts
@@ -22,26 +22,22 @@ export class Scanner {
         this.state = state;
         let lex = (this.state.inString ? multstring : toplevel).lex(line);
         let tk: Token;
-        try {
-            do {
-                tk = lex.scan();
-                if(tk) {
-                    let oldpos = lex.position;
-                    if(tk.type == "str-end") {
-                        this.state = { ...this.state, inString: false};
-                        lex = toplevel.lex(line);
-                        lex.position = oldpos;
-                    } else if (tk.type == "str-start") {
-                        this.state = { ...this.state, inString: true};
-                        lex = multstring.lex(line);
-                        lex.position = oldpos;
-                    }
-                    tks.push(tk);
+        do {
+            tk = lex.scan();
+            if(tk) {
+                let oldpos = lex.position;
+                if(tk.type == "str-end") {
+                    this.state = { ...this.state, inString: false};
+                    lex = toplevel.lex(line);
+                    lex.position = oldpos;
+                } else if (tk.type == "str-start") {
+                    this.state = { ...this.state, inString: true};
+                    lex = multstring.lex(line);
+                    lex.position = oldpos;
                 }
-            } while(tk);
-        } catch(e) {
-            debugger
-        }
+                tks.push(tk);
+            }
+        } while(tk);
         return tks;
     }
 }

--- a/calva-fmt/docmirror/clojure-lexer.ts
+++ b/calva-fmt/docmirror/clojure-lexer.ts
@@ -21,7 +21,7 @@ toplevel.terminal("[\\s,]+", (l, m) => ({ type: "ws" }))
 // comments
 toplevel.terminal(";.*", (l, m) => ({ type: "comment" }))
 // open parens
-toplevel.terminal("\\(|\\[|\\{|#\\(|#?\\(|#\\{", (l, m) => ({ type: "open" }))
+toplevel.terminal("\\(|\\[|\\{|#\\(|#?\\(|#\\{|#?@\\(", (l, m) => ({ type: "open" }))
 // close parens
 toplevel.terminal("\\)|\\]|\\}", (l, m) => ({ type: "close" }))
 

--- a/calva-fmt/docmirror/index.ts
+++ b/calva-fmt/docmirror/index.ts
@@ -629,17 +629,17 @@ export function collectIndentState(document: vscode.TextDocument, position: vsco
             exprsOnLine++;
         }
 
-        if(!indents.length && cursor.clone().previous().line != cursor.line) {
-            lastIndent = cursor.position.character;
-        }
-
         if(cursor.line != lastLine) {
+            let head = cursor.clone();
+            head.forwardSexp();
+            head.forwardWhitespace();
+            lastIndent = head.position.character;
             exprsOnLine = 0;
             lastLine = cursor.line;
         }
-    } while(!cursor.atEnd() && (Math.abs(startLine-cursor.line) < maxLines) && indents.length < maxDepth);
+    } while(!cursor.atEnd() && Math.abs(startLine-cursor.line) < maxLines && indents.length < maxDepth);
     if(!indents.length)
-        indents.push({argPos: 0, first: null, rules: [], exprsOnLine: 0, startIndent: lastIndent, firstItemIdent: lastIndent})
+        indents.push({argPos: 0, first: null, rules: [], exprsOnLine: 0, startIndent: lastIndent >= 0 ? lastIndent : 0, firstItemIdent: lastIndent >= 0 ? lastIndent : 0})
     return indents;
 }
 

--- a/calva-fmt/docmirror/index.ts
+++ b/calva-fmt/docmirror/index.ts
@@ -197,11 +197,11 @@ class DocumentMirror {
         if(line) {
             for(let i=0; i<line.tokens.length; i++) {
                 let tk = line.tokens[i];
-                if(tk.offset > pos.character)
+                if(previous ? tk.offset > pos.character : tk.offset >= pos.character)
                     return new TokenCursor(this, pos.line, previous ? Math.max(0, lastIndex-1) : lastIndex);
                 lastIndex = i;
             }
-            return new TokenCursor(this, pos.line, previous ? Math.max(0, lastIndex-1) : lastIndex);
+            return new TokenCursor(this, pos.line, line.tokens.length-1);
         }
     }
 
@@ -321,7 +321,7 @@ export function growSelection() {
         try {
             vscode.window.activeTextEditor.selection = new vscode.Selection(
                 mirror.getTokenCursor(vscode.window.activeTextEditor.selection.start).previousOpen(-1).start,
-                mirror.getTokenCursor(vscode.window.activeTextEditor.selection.end, true).nextClose(-1).end)
+                mirror.getTokenCursor(vscode.window.activeTextEditor.selection.end).nextClose(-1).end)
         } catch (e) {
             console.error(e);
         }

--- a/calva-fmt/docmirror/index.ts
+++ b/calva-fmt/docmirror/index.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import { Scanner, ScannerState, Token } from "./clojure-lexer";
-import { stat } from "fs";
 
 const scanner = new Scanner();
 

--- a/calva-fmt/docmirror/index.ts
+++ b/calva-fmt/docmirror/index.ts
@@ -6,10 +6,9 @@ const scanner = new Scanner();
 class ClojureSourceLine {
     tokens: Token[];
     endState: ScannerState;
-    constructor(public text: string, prevState: ScannerState) {
-        this.tokens = scanner.processLine(text, prevState)
+    constructor(public text: string, public startState: ScannerState) {
+        this.tokens = scanner.processLine(text, startState)
         this.endState = scanner.state;
-        console.log(this.tokens);
     }
 
     get length() {
@@ -18,6 +17,28 @@ class ClojureSourceLine {
 }
 
 let debugValidation = false
+
+function equal(x: any, y: any): boolean {
+    if(x==y) return true;
+    if(x instanceof Array && y instanceof Array) {
+        if(x.length == y.length) {
+            for(let i = 0; i<x.length; i++)
+                if(!equal(x[i], y[i]))
+                    return false;
+            return true;
+        } else
+            return false;
+    } else if (!(x instanceof Array) && !(y instanceof Array) && x instanceof Object && y instanceof Object) {
+        for(let f in x)
+            if(!equal(x[f], y[f]))
+                return false;
+        for(let f in y)
+            if(!x.hasOwnProperty(f))
+                return false
+        return true;
+    }
+    return false;
+}
 
 class DocumentMirror {
     lines: ClojureSourceLine[] = [];
@@ -32,35 +53,63 @@ class DocumentMirror {
     }
 
     changeRange(e: vscode.TextDocumentContentChangeEvent) {
+        // extract the lines we will replace
         let replaceLines = e.text.split(this.doc.eol == vscode.EndOfLine.LF ? /\n/ : /\r\n/);
+
+        // the left side of the line unaffected by the edit.
         let left = this.lines[e.range.start.line].text.substr(0, e.range.start.character);
+
+        // the right side of the line unaffected by the edit.
         let right = this.lines[e.range.end.line].text.substr(e.range.end.character);
 
         let items: ClojureSourceLine[] = [];
         
+        // initialize the lexer state - the first line is definitely not in a string, otherwise copy the
+        // end state of the previous line before the edit
         let state = e.range.start.line == 0 ? { inString: false } : this.lines[e.range.start.line-1].endState;
 
+        let lastLine: ClojureSourceLine;
         if(replaceLines.length == 1) {
-            items.push(new ClojureSourceLine(left + replaceLines[0] + right, state));
+            // trivial single line edit
+            items.push(lastLine = new ClojureSourceLine(left + replaceLines[0] + right, state));
         } else {
+            // multi line edit.
             items.push(new ClojureSourceLine(left + replaceLines[0], state));
-            for(let i=1; i<replaceLines.length-1; i++) {
+            for(let i=1; i<replaceLines.length-1; i++)
                 items.push(new ClojureSourceLine(replaceLines[i], scanner.state));
-            }
-            items.push(new ClojureSourceLine(replaceLines[replaceLines.length-1] + right, scanner.state))
+            items.push(lastLine = new ClojureSourceLine(replaceLines[replaceLines.length-1] + right, scanner.state))
         }
 
+        // now splice in our edited lines
         this.lines.splice(e.range.start.line, e.range.end.line-e.range.start.line+1, ...items);
+        let nextIdx = e.range.start.line+replaceLines.length
+        let nextLine = this.lines[nextIdx];
+        let prevState = lastLine.endState;
+        
+        while(nextLine && !equal(nextLine.startState, prevState)) {
+            // everything is desynced now, so scan forward until it is resolved.
+
+            // TODO: this should only really happen after all coalesced events have occured, and even possibly only
+            //       when we need to force computation because we need the parenthesis info. For example, we do not
+            //       need up to date information for the purposes of formatting for the lines below the cursor *ever*.
+            //       because " can toggle the entire file to be in/out of a string, it is important that we don't immediately touch
+            //       the whole file again. Waiting to perform this scan only when the cursor is moved, or on return would be enough.
+            //
+            //       This is a TODO because I need to track 'dirty' line #s, and update the indices as edits move them about.
+            
+            let newLine = new ClojureSourceLine(this.lines[nextIdx].text, prevState);
+            prevState = newLine.endState;
+            this.lines[nextIdx++] = newLine;
+            nextLine = this.lines[nextIdx];
+        }
     }
 
     processChanges(e: vscode.TextDocumentContentChangeEvent[]) {
-        for(let change of e) {
+        for(let change of e)
             this.changeRange(change);
-        }
         
-        if(debugValidation && this.doc.getText() != this.text) {
+        if(debugValidation && this.doc.getText() != this.text)
             vscode.window.showErrorMessage("DocumentMirror failed");
-        }
     }
 
     get text() {

--- a/calva-fmt/docmirror/index.ts
+++ b/calva-fmt/docmirror/index.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { Scanner, Token, ScannerState } from "./clojure-lexer";
+import { Scanner, ScannerState, Token } from "./clojure-lexer";
 
 const scanner = new Scanner();
 
@@ -47,14 +47,26 @@ class DocumentMirror {
     dirtyLines: number[] = [];
 
     constructor(public doc: vscode.TextDocument) {
-        scanner.state = { inString: false, paren: null }
+        scanner.state = this.getStateForLine(0);
         for(let i=0; i<doc.lineCount; i++) {
             let line = doc.lineAt(i);
             this.lines.push(new ClojureSourceLine(line.text, scanner.state, i));
         }
     }
 
+    rescanAll() {
+        scanner.state = this.getStateForLine(0);
+        this.lines = [];
+        let now = Date.now();
+        for(let i=0; i<this.doc.lineCount; i++) {
+            let line = this.doc.lineAt(i);
+            this.lines.push(new ClojureSourceLine(line.text, scanner.state, i));
+        }
+        console.log("Rescanned document in "+(Date.now()-now)+"ms");
+    }
+
     private markDirty(idx: number) {
+        if(idx >= 0 && idx < this.lines.length)
         if(this.dirtyLines.indexOf(idx) == -1)
             this.dirtyLines.push(idx);
     }
@@ -65,8 +77,23 @@ class DocumentMirror {
                                           .map(x => x > start ? x - delta : x);
     }
     
-    private getStateForLine(line: number) {
-        return line == 0 ? { inString: false, paren: null } : this.lines[line-1].endState;
+    private getStateForLine(line: number): ScannerState {
+        return line == 0 ? { inString: false, paren: null, line, character: 0 } : { ... this.lines[line-1].endState, line, character: 0 };
+    }
+
+    public getTokenAt(range: vscode.Position): Token {
+        this.flushChanges();
+        let line = this.lines[range.line]
+        if(line) {
+            let lastToken = null;
+            for(let i=0; i<line.tokens.length; i++) {
+                let tk = line.tokens[i];
+                if(tk.offset > range.character)
+                    return lastToken;
+                lastToken = tk;
+            }
+            return lastToken;
+        }
     }
 
     private changeRange(e: vscode.TextDocumentContentChangeEvent) {
@@ -88,26 +115,21 @@ class DocumentMirror {
         // end state of the previous line before the edit
         let state = this.getStateForLine(e.range.start.line)
 
-        let lastLine: ClojureSourceLine;
         if(replaceLines.length == 1) {
             // trivial single line edit
-            items.push(lastLine = new ClojureSourceLine(left + replaceLines[0] + right, state, e.range.start.line));
+            items.push(new ClojureSourceLine(left + replaceLines[0] + right, state, e.range.start.line));
         } else {
             // multi line edit.
             items.push(new ClojureSourceLine(left + replaceLines[0], state, e.range.start.line));
             for(let i=1; i<replaceLines.length-1; i++)
                 items.push(new ClojureSourceLine(replaceLines[i], scanner.state, e.range.start.line+i));
-            items.push(lastLine = new ClojureSourceLine(replaceLines[replaceLines.length-1] + right, scanner.state, e.range.start.line+replaceLines.length))
+            items.push(new ClojureSourceLine(replaceLines[replaceLines.length-1] + right, scanner.state, e.range.start.line+replaceLines.length))
         }
 
         // now splice in our edited lines
         this.lines.splice(e.range.start.line, e.range.end.line-e.range.start.line+1, ...items);
-        let nextIdx = e.range.start.line+replaceLines.length
-        let nextLine = this.lines[nextIdx];
-        
-        if(nextLine && !equal(nextLine.startState, lastLine.endState))
-            this.markDirty(nextIdx); // everything is desynced now, so mark this line.
-        console.log(this.dirtyLines);
+        let nextIdx = e.range.start.line
+        this.markDirty(nextIdx+1);
     }
 
     flushChanges() {
@@ -117,15 +139,15 @@ class DocumentMirror {
             let nextIdx = this.dirtyLines.shift();
             if(seen.has(nextIdx))
                 continue; // already processed.
-
             seen.add(nextIdx);
             let prevState = this.getStateForLine(nextIdx);
             let newLine: ClojureSourceLine;
             do {
-                newLine = new ClojureSourceLine(this.lines[nextIdx].text, prevState, nextIdx+1);
+                seen.add(nextIdx);
+                newLine = new ClojureSourceLine(this.lines[nextIdx].text, prevState, nextIdx);
                 prevState = newLine.endState;
-                this.lines[nextIdx++] = newLine;    
-            } while(this.lines[nextIdx] && !(equal(this.lines[nextIdx].startState, newLine.endState)))
+                this.lines[nextIdx] = newLine;    
+            } while(this.lines[++nextIdx] && !(equal(this.lines[nextIdx].startState, prevState)))
         }
     }
 
@@ -166,4 +188,33 @@ export function activate() {
                 documents.get(e.document).processChanges(e.contentChanges)
         }
     })
+}
+
+export function getDocument(doc: vscode.TextDocument) {
+    if(doc.languageId == "clojure") {
+        if(!documents.get(doc))
+            documents.set(doc, new DocumentMirror(doc));
+        return documents.get(doc);
+    }
+}
+
+/**
+ * Temporary formatting commands
+ * 
+ * These won't live here.
+ */
+export function growSelection() {
+    let doc = vscode.window.activeTextEditor.document
+    let mirror = getDocument(doc);
+    if(mirror) {
+        let pos = doc.positionAt(Math.max(0, doc.offsetAt(vscode.window.activeTextEditor.selection.start)-1));
+        let tk = mirror.getTokenAt(pos);
+        if(tk) {
+            if(tk.state.paren) {
+                let p = tk.state.paren;
+                let pos = new vscode.Position(p.line, p.character);
+                vscode.window.activeTextEditor.selection = new vscode.Selection(pos, pos);
+            }
+        }
+    }
 }

--- a/calva-fmt/docmirror/index.ts
+++ b/calva-fmt/docmirror/index.ts
@@ -214,6 +214,45 @@ class TokenCursor {
         return false;
     }
 
+    downList(): boolean {
+        let cursor = this.clone();
+        do {
+            cursor.forwardWhitespace();
+            if(cursor.getToken().type == "open") {
+                cursor.next();
+                this.set(cursor);
+                return true;
+            }
+        } while(cursor.forwardSexp())
+        return false;
+    }
+
+    upList(): boolean {
+        let cursor = this.clone();
+        do {
+            cursor.forwardWhitespace();
+            if(cursor.getToken().type == "close") {
+                cursor.next();
+                this.set(cursor);
+                return true;
+            }
+        } while(cursor.forwardSexp())
+        return false;
+    }
+
+    backwardUpList(): boolean {
+        let cursor = this.clone();
+        do {
+            cursor.backwardWhitespace();
+            if(cursor.getPrevToken().type == "open") {
+                cursor.previous();
+                this.set(cursor);
+                return true;
+            }
+        } while(cursor.backwardSexp())
+        return false;
+    }
+
     getPrevToken() {
         this.previous();
         let tk = this.getToken();
@@ -438,5 +477,26 @@ export function backwardList() {
     let textEditor = vscode.window.activeTextEditor;
     let cursor = getDocument(textEditor.document).getTokenCursor(textEditor.selection.start);
     cursor.backwardList();
+    textEditor.selection = new vscode.Selection(cursor.position, cursor.position);    
+}
+
+export function downList() {
+    let textEditor = vscode.window.activeTextEditor;
+    let cursor = getDocument(textEditor.document).getTokenCursor(textEditor.selection.start);
+    cursor.downList();
+    textEditor.selection = new vscode.Selection(cursor.position, cursor.position);    
+}
+
+export function upList() {
+    let textEditor = vscode.window.activeTextEditor;
+    let cursor = getDocument(textEditor.document).getTokenCursor(textEditor.selection.start);
+    cursor.upList();
+    textEditor.selection = new vscode.Selection(cursor.position, cursor.position);    
+}
+
+export function backwardUpList() {
+    let textEditor = vscode.window.activeTextEditor;
+    let cursor = getDocument(textEditor.document).getTokenCursor(textEditor.selection.start);
+    cursor.backwardUpList();
     textEditor.selection = new vscode.Selection(cursor.position, cursor.position);    
 }

--- a/calva-fmt/docmirror/index.ts
+++ b/calva-fmt/docmirror/index.ts
@@ -1,0 +1,94 @@
+import * as vscode from "vscode";
+import { Scanner, Token, ScannerState } from "./clojure-lexer";
+
+const scanner = new Scanner();
+
+class ClojureSourceLine {
+    tokens: Token[];
+    endState: ScannerState;
+    constructor(public text: string, prevState: ScannerState) {
+        this.tokens = scanner.processLine(text, prevState)
+        this.endState = scanner.state;
+        console.log(this.tokens);
+    }
+
+    get length() {
+        return this.text.length;
+    }
+}
+
+let debugValidation = false
+
+class DocumentMirror {
+    lines: ClojureSourceLine[] = [];
+    scanner = new Scanner();
+
+    constructor(public doc: vscode.TextDocument) {
+        scanner.state = { inString: false }
+        for(let i=0; i<doc.lineCount; i++) {
+            let line = doc.lineAt(i);
+            this.lines.push(new ClojureSourceLine(line.text, scanner.state));
+        }
+    }
+
+    changeRange(e: vscode.TextDocumentContentChangeEvent) {
+        let replaceLines = e.text.split(this.doc.eol == vscode.EndOfLine.LF ? /\n/ : /\r\n/);
+        let left = this.lines[e.range.start.line].text.substr(0, e.range.start.character);
+        let right = this.lines[e.range.end.line].text.substr(e.range.end.character);
+
+        let items: ClojureSourceLine[] = [];
+        
+        let state = e.range.start.line == 0 ? { inString: false } : this.lines[e.range.start.line-1].endState;
+
+        if(replaceLines.length == 1) {
+            items.push(new ClojureSourceLine(left + replaceLines[0] + right, state));
+        } else {
+            items.push(new ClojureSourceLine(left + replaceLines[0], state));
+            for(let i=1; i<replaceLines.length-1; i++) {
+                items.push(new ClojureSourceLine(replaceLines[i], scanner.state));
+            }
+            items.push(new ClojureSourceLine(replaceLines[replaceLines.length-1] + right, scanner.state))
+        }
+
+        this.lines.splice(e.range.start.line, e.range.end.line-e.range.start.line+1, ...items);
+    }
+
+    processChanges(e: vscode.TextDocumentContentChangeEvent[]) {
+        for(let change of e) {
+            this.changeRange(change);
+        }
+        
+        if(debugValidation && this.doc.getText() != this.text) {
+            vscode.window.showErrorMessage("DocumentMirror failed");
+        }
+    }
+
+    get text() {
+        return this.lines.map(x => x.text).join(this.doc.eol == vscode.EndOfLine.LF ? "\n" : "\r\n");
+    }
+}
+
+let documents = new Map<vscode.TextDocument, DocumentMirror>();
+
+let registered = false;
+export function activate() {
+    // the last thing we want is to register twice and receive double events...
+    if(registered)
+        return;
+    registered = true;
+
+    vscode.workspace.onDidCloseTextDocument(e => {
+        if(e.languageId == "clojure") {
+            documents.delete(e);
+        }
+    })
+
+    vscode.workspace.onDidChangeTextDocument(e => {
+        if(e.document.languageId == "clojure") {
+            if(!documents.get(e.document))
+                documents.set(e.document, new DocumentMirror(e.document));
+            else
+                documents.get(e.document).processChanges(e.contentChanges)
+        }
+    })
+}

--- a/calva-fmt/docmirror/index.ts
+++ b/calva-fmt/docmirror/index.ts
@@ -590,6 +590,8 @@ interface IndentState {
     exprsOnLine: number;
 }
 
+let OPEN_LIST = new Set(["#(", "#?(", "("])
+
 export function collectIndentState(document: vscode.TextDocument, position: vscode.Position, maxDepth: number = 3, maxLines: number = 20): IndentState[] {
     let cursor = getDocument(document).getTokenCursor(position);
     let argPos = 0;
@@ -609,7 +611,7 @@ export function collectIndentState(document: vscode.TextDocument, position: vsco
             nextCursor.forwardSexp()
             nextCursor.forwardWhitespace();
 
-            let firstItemIdent = nextCursor.line == cursor.line ? nextCursor.position.character : -1;
+            let firstItemIdent = nextCursor.line == cursor.line && OPEN_LIST.has(prevToken.raw) ? nextCursor.position.character : cursor.position.character;
 
 
             let token = cursor.getToken().raw;

--- a/calva-fmt/docmirror/index.ts
+++ b/calva-fmt/docmirror/index.ts
@@ -136,7 +136,7 @@ class TokenCursor {
                     do {
                         this.next();
                         tk = this.getToken();
-                    } while(tk.type == "str-inside" || tk.type == "eol")
+                    } while(!this.atEnd() && (tk.type == "str-inside" || tk.type == "eol"))
                     continue;
                 case 'close':
                     delta--;
@@ -178,7 +178,7 @@ class TokenCursor {
                     do {
                         this.previous();
                         tk = this.getPrevToken();
-                    } while(tk.type == "str-inside")
+                    } while(!this.atStart() && tk.type == "str-inside")
                     continue;                    
                 case 'close':
                     delta++;

--- a/calva-fmt/docmirror/index.ts
+++ b/calva-fmt/docmirror/index.ts
@@ -18,9 +18,6 @@ class ClojureSourceLine {
 
 let debugValidation = false
 
-const OPEN = new Set(["(", "#{", "[", "{", "#(", "#?("])
-const CLOSE = new Set([")", "]", "}"])
-
 class TokenCursor {
     constructor(public doc: DocumentMirror, public line: number, public token: number, public deltaDepth = 0) {
     }
@@ -50,12 +47,10 @@ class TokenCursor {
             this.token = this.doc.lines[this.line].tokens.length-1;
         }
         const tk = this.getToken()
-        if(tk.type == "punc") {
-            if(OPEN.has(tk.raw))
-                this.deltaDepth--;
-            else if(CLOSE.has(tk.raw))
-                this.deltaDepth++;
-        }
+        if(tk.type == "open")
+            this.deltaDepth--;
+        else if(tk.type == "close")
+            this.deltaDepth++;
         return this;
     }
 
@@ -68,12 +63,10 @@ class TokenCursor {
             this.token = 0;
         }
         const tk = this.getToken();
-        if(tk.type == "punc") {
-            if(OPEN.has(tk.raw))
-                this.deltaDepth++;
-            else if(CLOSE.has(tk.raw))
-                this.deltaDepth--;
-        }
+        if(tk.type == "open")
+            this.deltaDepth++;
+        else if(tk.type == "close")
+            this.deltaDepth--;
         return this;
     }
 
@@ -82,7 +75,7 @@ class TokenCursor {
         while(!this.atStart()) {
             this.previous();
             const tk = this.getToken();
-            if(tk.type == "punc" && OPEN.has(tk.raw) && this.deltaDepth == depth)
+            if(tk.type == "open" && this.deltaDepth == depth)
                 return this;
         }
         return this;
@@ -93,7 +86,7 @@ class TokenCursor {
         while(!this.atStart()) {
             this.previous();
             const tk = this.getToken();
-            if(tk.type == "punc" && CLOSE.has(tk.raw) && this.deltaDepth == depth)
+            if(tk.type == "close" && this.deltaDepth == depth)
                 return this;
         }
         return this;
@@ -104,7 +97,7 @@ class TokenCursor {
         while(!this.atEnd()) {
             this.next();
             const tk = this.getToken();
-            if(tk.type == "punc" && OPEN.has(tk.raw) && this.deltaDepth == depth)
+            if(tk.type == "open" && this.deltaDepth == depth)
                 return this;
         }
         return this;
@@ -112,11 +105,10 @@ class TokenCursor {
 
     nextClose(depth: number = 0) {
         depth += this.deltaDepth;
-        debugValidation
         while(!this.atEnd()) {
             this.next();
             const tk = this.getToken();
-            if(tk.type == "punc" && CLOSE.has(tk.raw) && this.deltaDepth == depth)
+            if(tk.type == "close" && this.deltaDepth == depth)
                 return this;
         }
         return this;

--- a/calva-fmt/docmirror/index.ts
+++ b/calva-fmt/docmirror/index.ts
@@ -301,9 +301,17 @@ export function growSelection() {
     let mirror = getDocument(doc);
     if(mirror) {
         try {
+            let selection = vscode.window.activeTextEditor.selection;
+            let prevCursor = mirror.getTokenCursor(selection.start);
+            let nextCursor = mirror.getTokenCursor(selection.end);
+            if(prevCursor.getToken().type == "close") {
+                prevCursor.previous();
+                if(doc.offsetAt(selection.start) == doc.offsetAt(selection.end))
+                    nextCursor.previous();
+            }
             vscode.window.activeTextEditor.selection = new vscode.Selection(
-                mirror.getTokenCursor(vscode.window.activeTextEditor.selection.start).findPrev("open", -1).start,
-                mirror.getTokenCursor(vscode.window.activeTextEditor.selection.end).findNext("close", -1).end)
+                prevCursor.findPrev("open", -1).start,
+                nextCursor.findNext("close", -1).end)
         } catch (e) {
             console.error(e);
         }

--- a/calva-fmt/docmirror/lexer.ts
+++ b/calva-fmt/docmirror/lexer.ts
@@ -19,10 +19,8 @@ export interface Rule {
  * create one of these.
  *
  * @class
- * @param context a context object for this lexer.
- * @param {FileInfo} source
+ * @param {string} source the source code to parse
  * @param rules the rules of this lexer.
- * @param {boolean?} skipWhiteSpace if true- terminals who's type is "ws" are discarded.
  */
 export class Lexer {
     position: number = 0;
@@ -68,7 +66,6 @@ export class Lexer {
                 return null;
             throw new Error("Unexpected character at " + this.position + ": "+JSON.stringify(this.source));
         }
-            
         return token;
     }
 }
@@ -84,7 +81,7 @@ export class LexicalGrammar {
      * Defines a terminal with the given pattern and constructor.
      * @param {string} pattern the pattern this nonterminal must match.
      * @param {function(Array<string>): Object} fn returns a lexical token representing
-     *        this terminal.  An additional "si" property containing the token source position
+     *        this terminal.  An additional "offset" property containing the token source position
      *        will also be added, as well as a "raw" property, containing the raw string match.
      */
     terminal(pattern: string, fn: (T, RegExpExecArray) => any): void {

--- a/calva-fmt/docmirror/lexer.ts
+++ b/calva-fmt/docmirror/lexer.ts
@@ -1,0 +1,97 @@
+/**
+ * A Lexical analyser
+ * @module lexer
+ */
+
+export interface Token {
+    type: string;
+    raw: string;
+    offset: number;
+}
+
+export interface Rule {
+    r: RegExp;
+    fn: (Lexer, RegExpExecArray) => any
+}
+
+/**
+ * A Lexer instance, parsing a given file.  Usually you should use a LexicalGrammar to
+ * create one of these.
+ *
+ * @class
+ * @param context a context object for this lexer.
+ * @param {FileInfo} source
+ * @param rules the rules of this lexer.
+ * @param {boolean?} skipWhiteSpace if true- terminals who's type is "ws" are discarded.
+ */
+export class Lexer {
+    position: number = 0;
+    constructor(public source: string, public rules: Rule[]) {
+    }
+
+    peeked: any;
+
+    peek() {
+        return this.peeked = this.scan();
+    }
+
+    match(type: string, raw?: string) {
+        let p = this.peek();
+        if(p && p.type == type && (!raw || p.raw == raw)) {
+            this.peeked = null;
+            return true;
+        }
+        return false;
+    }
+
+    scan(): Token {
+        if(this.peeked) {
+            let res = this.peeked;
+            this.peeked = null;
+            return res;
+        }
+        var token = null;
+        var length = 0;
+        this.rules.forEach(rule => {
+            rule.r.lastIndex = this.position;
+            var x = rule.r.exec(this.source);
+            if (x && x[0].length > length && this.position + x[0].length == rule.r.lastIndex) {
+                token = rule.fn(this, x);
+                token.offset = this.position;
+                token.raw = x[0];
+                length = x[0].length;
+            }
+        })
+        this.position += length;
+        if (token == null) {
+            if(this.position == this.source.length)
+                return null;
+            throw new Error("Unexpected character at " + this.position + ": "+JSON.stringify(this.source));
+        }
+            
+        return token;
+    }
+}
+
+/**
+ * A lexical grammar- factory for lexer instances.
+ * @class
+ */
+export class LexicalGrammar {
+    rules: Rule[] = [];
+
+    /**
+     * Defines a terminal with the given pattern and constructor.
+     * @param {string} pattern the pattern this nonterminal must match.
+     * @param {function(Array<string>): Object} fn returns a lexical token representing
+     *        this terminal.  An additional "si" property containing the token source position
+     *        will also be added, as well as a "raw" property, containing the raw string match.
+     */
+    terminal(pattern: string, fn: (T, RegExpExecArray) => any): void {
+        this.rules.push({ r: new RegExp(pattern, "g"), fn: fn })
+    }
+
+    lex(source: string): Lexer {
+        return new Lexer(source, this.rules)
+    }
+}

--- a/calva-fmt/extension.ts
+++ b/calva-fmt/extension.ts
@@ -29,6 +29,9 @@ function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.backwardSexp', docmirror.backwardSexp))
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.forwardList', docmirror.forwardList))
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.backwardList', docmirror.backwardList))
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.downList', docmirror.downList))
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.upList', docmirror.upList))
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.backwardUpList', docmirror.backwardUpList))
     
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.formatCurrentForm', formatter.formatPositionCommand));
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.alignCurrentForm', formatter.alignPositionCommand));

--- a/calva-fmt/extension.ts
+++ b/calva-fmt/extension.ts
@@ -4,6 +4,7 @@ import { RangeEditProvider } from './providers/range_formatter';
 import * as formatter from './format';
 import * as inferer from './infer';
 import * as docmirror from "./docmirror"
+
 const ClojureLanguageConfiguration: vscode.LanguageConfiguration = {
     wordPattern: /[^\s#()[\]{};"\\]+/,
     onEnterRules: [
@@ -23,6 +24,8 @@ const ClojureLanguageConfiguration: vscode.LanguageConfiguration = {
 function activate(context: vscode.ExtensionContext) {
     docmirror.activate();
     vscode.languages.setLanguageConfiguration("clojure", ClojureLanguageConfiguration);
+    // this doesn't actually grow anything yet, but just jumps to the start of the enclosing expression.
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.growSelection', docmirror.growSelection))
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.formatCurrentForm', formatter.formatPositionCommand));
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.alignCurrentForm', formatter.alignPositionCommand));
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.inferParens', inferer.inferParensCommand));

--- a/calva-fmt/extension.ts
+++ b/calva-fmt/extension.ts
@@ -3,7 +3,7 @@ import { FormaOnTypeEditProvider } from './providers/ontype_formatter';
 import { RangeEditProvider } from './providers/range_formatter';
 import * as formatter from './format';
 import * as inferer from './infer';
-
+import * as docmirror from "./docmirror"
 const ClojureLanguageConfiguration: vscode.LanguageConfiguration = {
     wordPattern: /[^\s#()[\]{};"\\]+/,
     onEnterRules: [
@@ -21,6 +21,7 @@ const ClojureLanguageConfiguration: vscode.LanguageConfiguration = {
 
 
 function activate(context: vscode.ExtensionContext) {
+    docmirror.activate();
     vscode.languages.setLanguageConfiguration("clojure", ClojureLanguageConfiguration);
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.formatCurrentForm', formatter.formatPositionCommand));
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.alignCurrentForm', formatter.alignPositionCommand));

--- a/calva-fmt/extension.ts
+++ b/calva-fmt/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { FormaOnTypeEditProvider } from './providers/ontype_formatter';
+import { FormatOnTypeEditProvider } from './providers/ontype_formatter';
 import { RangeEditProvider } from './providers/range_formatter';
 import * as formatter from './format';
 import * as inferer from './infer';
@@ -38,7 +38,7 @@ function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.inferParens', inferer.inferParensCommand));
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.tabIndent', (e) => { inferer.indentCommand(e, " ", true) }));
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.tabDedent', (e) => { inferer.indentCommand(e, " ", false) }));
-    context.subscriptions.push(vscode.languages.registerOnTypeFormattingEditProvider("clojure", new FormaOnTypeEditProvider, "\r", "\n"));
+    context.subscriptions.push(vscode.languages.registerOnTypeFormattingEditProvider("clojure", new FormatOnTypeEditProvider, "\r", "\n"));
     context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider("clojure", new RangeEditProvider));
     vscode.window.onDidChangeActiveTextEditor(inferer.updateState);
     // vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {

--- a/calva-fmt/extension.ts
+++ b/calva-fmt/extension.ts
@@ -27,6 +27,9 @@ function activate(context: vscode.ExtensionContext) {
     // this doesn't actually grow anything yet, but just jumps to the start of the enclosing expression.
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.forwardSexp', docmirror.forwardSexp))
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.backwardSexp', docmirror.backwardSexp))
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.forwardList', docmirror.forwardList))
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.backwardList', docmirror.backwardList))
+    
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.formatCurrentForm', formatter.formatPositionCommand));
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.alignCurrentForm', formatter.alignPositionCommand));
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.inferParens', inferer.inferParensCommand));

--- a/calva-fmt/extension.ts
+++ b/calva-fmt/extension.ts
@@ -25,7 +25,8 @@ function activate(context: vscode.ExtensionContext) {
     docmirror.activate();
     vscode.languages.setLanguageConfiguration("clojure", ClojureLanguageConfiguration);
     // this doesn't actually grow anything yet, but just jumps to the start of the enclosing expression.
-    context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.growSelection', docmirror.growSelection))
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.forwardSexp', docmirror.forwardSexp))
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.backwardSexp', docmirror.backwardSexp))
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.formatCurrentForm', formatter.formatPositionCommand));
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.alignCurrentForm', formatter.alignPositionCommand));
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('calva-fmt.inferParens', inferer.inferParensCommand));

--- a/calva-fmt/providers/ontype_formatter.ts
+++ b/calva-fmt/providers/ontype_formatter.ts
@@ -1,10 +1,29 @@
 import * as vscode from 'vscode';
 import * as formatter from '../format';
-
+import { getDocument, getIndent } from "../docmirror";
 export class FormaOnTypeEditProvider {
     provideOnTypeFormattingEdits(document: vscode.TextDocument, position: vscode.Position, _ch, _options) {
         if (vscode.workspace.getConfiguration("calva.fmt").get("formatAsYouType")) {
-            formatter.formatPosition(vscode.window.activeTextEditor, true);
+            let editor = vscode.window.activeTextEditor;
+            let pos = new vscode.Position(position.line, 0);
+            let indent = getIndent(document, pos)
+            
+            /*
+            if(editor.document == document)
+                setTimeout(() => {
+                    let endPos = new vscode.Position(pos.line, indent)
+                    editor.selection = new vscode.Selection(endPos, endPos);
+                },1)
+            */  
+            let delta = document.lineAt(position.line).firstNonWhitespaceCharacterIndex-indent;
+            if(delta > 0) {
+                editor.edit(edits => edits.delete(new vscode.Range(pos, new vscode.Position(pos.line, delta))));
+            } else if(delta < 0) {
+                let str = "";
+                while(delta++ < 0)
+                    str += " "
+                editor.edit(edits => edits.insert(pos, str));
+            }
         }
         return null;
     }

--- a/calva-fmt/providers/ontype_formatter.ts
+++ b/calva-fmt/providers/ontype_formatter.ts
@@ -2,27 +2,19 @@ import * as vscode from 'vscode';
 import * as formatter from '../format';
 import { getDocument, getIndent } from "../docmirror";
 export class FormaOnTypeEditProvider {
-    provideOnTypeFormattingEdits(document: vscode.TextDocument, position: vscode.Position, _ch, _options) {
+    async provideOnTypeFormattingEdits(document: vscode.TextDocument, position: vscode.Position, _ch, _options) {
         if (vscode.workspace.getConfiguration("calva.fmt").get("formatAsYouType")) {
-            let editor = vscode.window.activeTextEditor;
             let pos = new vscode.Position(position.line, 0);
             let indent = getIndent(document, pos)
             
-            /*
-            if(editor.document == document)
-                setTimeout(() => {
-                    let endPos = new vscode.Position(pos.line, indent)
-                    editor.selection = new vscode.Selection(endPos, endPos);
-                },1)
-            */  
             let delta = document.lineAt(position.line).firstNonWhitespaceCharacterIndex-indent;
             if(delta > 0) {
-                editor.edit(edits => edits.delete(new vscode.Range(pos, new vscode.Position(pos.line, delta))));
+                return [vscode.TextEdit.delete(new vscode.Range(pos, new vscode.Position(pos.line, delta)))];
             } else if(delta < 0) {
                 let str = "";
                 while(delta++ < 0)
                     str += " "
-                editor.edit(edits => edits.insert(pos, str));
+                return [vscode.TextEdit.insert(pos, str)];
             }
         }
         return null;

--- a/calva-fmt/providers/ontype_formatter.ts
+++ b/calva-fmt/providers/ontype_formatter.ts
@@ -1,20 +1,23 @@
 import * as vscode from 'vscode';
 import * as formatter from '../format';
 import { getDocument, getIndent } from "../docmirror";
-export class FormaOnTypeEditProvider {
+export class FormatOnTypeEditProvider {
     async provideOnTypeFormattingEdits(document: vscode.TextDocument, position: vscode.Position, _ch, _options) {
         if (vscode.workspace.getConfiguration("calva.fmt").get("formatAsYouType")) {
+            let editor = vscode.window.activeTextEditor;
             let pos = new vscode.Position(position.line, 0);
             let indent = getIndent(document, pos)
             
             let delta = document.lineAt(position.line).firstNonWhitespaceCharacterIndex-indent;
             if(delta > 0) {
-                return [vscode.TextEdit.delete(new vscode.Range(pos, new vscode.Position(pos.line, delta)))];
+                //return [vscode.TextEdit.delete(new vscode.Range(pos, new vscode.Position(pos.line, delta)))];
+                editor.edit(edits => edits.delete(new vscode.Range(pos, new vscode.Position(pos.line, delta))), { undoStopAfter: false, undoStopBefore: false });
             } else if(delta < 0) {
                 let str = "";
                 while(delta++ < 0)
                     str += " "
-                return [vscode.TextEdit.insert(pos, str)];
+                //return [vscode.TextEdit.insert(pos, str)];
+                editor.edit(edits => edits.insert(pos, str), { undoStopAfter: false, undoStopBefore: false });
             }
         }
         return null;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
     "contributes": {
         "commands": [
             {
+                "command": "calva-fmt.growSelection",
+                "title": "Grow Selection",
+                "category": "Calva Format (restartable-formatter)"
+            },
+            {
                 "command": "calva-fmt.formatCurrentForm",
                 "title": "Format Current Form",
                 "category": "Calva Format"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
                 "title": "Backward Up List",
                 "category": "Calva Format (restartable-formatter)"
             },
+            {
+                "command": "calva-fmt.argumentPosition",
+                "title": "Dump Argument Position",
+                "category": "Calva Format (restartable-formatter)"
+            },
             
             {
                 "command": "calva-fmt.formatCurrentForm",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,13 @@
     "contributes": {
         "commands": [
             {
-                "command": "calva-fmt.growSelection",
-                "title": "Grow Selection",
+                "command": "calva-fmt.forwardSexp",
+                "title": "Forward Sexp",
+                "category": "Calva Format (restartable-formatter)"
+            },
+            {
+                "command": "calva-fmt.backwardSexp",
+                "title": "Backward Sexp",
                 "category": "Calva Format (restartable-formatter)"
             },
             {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,16 @@
                 "category": "Calva Format (restartable-formatter)"
             },
             {
+                "command": "calva-fmt.forwardList",
+                "title": "Forward List",
+                "category": "Calva Format (restartable-formatter)"
+            },
+            {
+                "command": "calva-fmt.backwardList",
+                "title": "Backward List",
+                "category": "Calva Format (restartable-formatter)"
+            },
+            {
                 "command": "calva-fmt.formatCurrentForm",
                 "title": "Format Current Form",
                 "category": "Calva Format"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,22 @@
                 "category": "Calva Format (restartable-formatter)"
             },
             {
+                "command": "calva-fmt.downList",
+                "title": "Down List",
+                "category": "Calva Format (restartable-formatter)"
+            },
+            {
+                "command": "calva-fmt.upList",
+                "title": "Up List",
+                "category": "Calva Format (restartable-formatter)"
+            },
+            {
+                "command": "calva-fmt.backwardUpList",
+                "title": "Backward Up List",
+                "category": "Calva Format (restartable-formatter)"
+            },
+            
+            {
                 "command": "calva-fmt.formatCurrentForm",
                 "title": "Format Current Form",
                 "category": "Calva Format"


### PR DESCRIPTION
Core ontype-formatter logic for `calva-fmt`. Attempts to mimic `cljfmt` as best as it can, while doing as little work as possible.  Mirrors changes to a document inside `DocumentMirror`, in order to maintain a correctly lexically analysed document without having to touch the entire file.

Navigation throughout the document is provided by a mutable `TokenCursor` class, which can be initialized at a point in the file, and wound forwards and backwards tokens, up to a parent expression, over sibling expressions and down into expressions.

Caveats:
* Cannot yet be customized, everything is just hardwired to the clojure definitions in `cljfmt`.
* Does not support regex keys in cljfmt definitions.
* Does not support `ns-aliases`, and treats `xyz/foo` as distinct from `foo`.